### PR TITLE
Settings Page: add copy to clipboard for did/wallet info, remove logout

### DIFF
--- a/src/containers/Settings/index.js
+++ b/src/containers/Settings/index.js
@@ -5,6 +5,7 @@ import { get } from 'lodash'
 import { Button, Card, CardContent, CardActions, CardHeader } from '@material-ui/core'
 import { Avatar, withStyles, List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core'
 import ConfirmActionModal from 'components/Modals/ConfirmActionModal';
+import ReactCopyToClipBoard from 'react-copy-to-clipboard'
 // redux
 import { compose } from 'recompose';
 import { connect } from 'react-redux'
@@ -18,6 +19,7 @@ import DeleteIcon from '@material-ui/icons/Delete'
 import UserIcon from '@material-ui/icons/Person'
 import WalletIcon from '@material-ui/icons/AccountBalanceWallet'
 import ProfileIcon from '@material-ui/icons/AccountBalanceWallet'
+import KeyIcon from '@material-ui/icons/Lock'
 
 const cardStyle = {
   card: {
@@ -32,15 +34,11 @@ class Settings extends Component {
 
   handleDownload = () => downloadWallet(this.props.wallet)
 
-  deleteWallet = () => {
-    this.props.deleteWallet()
-    this.props.push('/')
-  }
-
   render () {
-    const { wallet, classes, isModalOpen, closeDeleteModal, openDeleteModal } = this.props
+    const { wallet, classes } = this.props
     const address = getAddress(wallet)
     const didId = get(wallet, 'did.publicDidDocument.id', '')
+    const didPrivateKey = get(wallet, 'did.privateKeyBase58', '')
 
     return <Card className={classes.card}>
       <CardHeader
@@ -50,53 +48,49 @@ class Settings extends Component {
       />
       <CardContent>
         <List dense disablePadding>
-            <ListItem>
+          <ReactCopyToClipBoard text={didId}>
+            <ListItem button>
                 <ListItemIcon><UserIcon/></ListItemIcon>
                 <ListItemText
                     primary='Distributed Identity (DID)'
-                    secondary={didId}
+                    secondary={`${didId} - Click to copy to clipboard`}
                 />
             </ListItem>
-            <ListItem>
+          </ReactCopyToClipBoard>
+          <ReactCopyToClipBoard text={didPrivateKey}>
+            <ListItem button>
+                <ListItemIcon><KeyIcon/></ListItemIcon>
+                <ListItemText
+                    primary='DID Private Key'
+                    secondary='Click to copy to clipboard'
+                />
+            </ListItem>
+          </ReactCopyToClipBoard>
+          <ReactCopyToClipBoard text={address}>
+            <ListItem button>
                 <ListItemIcon><WalletIcon/></ListItemIcon>
                 <ListItemText
                     primary='Bitcoin Wallet (testnet)'
-                    secondary={address}
+                    secondary={`${address} - Click to copy to clipboard`}
                 />
             </ListItem>
+          </ReactCopyToClipBoard>
         </List>
       </CardContent>
       <CardActions>
         <Button variant='raised' onClick={this.handleDownload}>
-          <DownloadIcon/> Download
-        </Button>
-        <Button variant='raised' color='secondary' onClick={openDeleteModal}>
-          <DeleteIcon/> Log Out
+          <DownloadIcon/> Download Wallet
         </Button>
       </CardActions>
-      <ConfirmActionModal
-        isOpen={isModalOpen}
-        confirm={this.deleteWallet.bind(this)}
-        cancel={closeDeleteModal}
-        text='Download the wallet before logging out or you will lose your funds and identity!'
-      />
     </Card>
   }
 }
 
 const mapStateToProps = store => ({
-  wallet: store.data.wallet,
-  isModalOpen: store.data.wallet.isDeleteModalOpen
+  wallet: store.data.wallet
 })
 
-const mapDispatchToProps = {
-  deleteWallet,
-  closeDeleteModal,
-  openDeleteModal,
-  push
-}
-
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps),
   withStyles(cardStyle)
 )(Settings)

--- a/src/containers/Settings/index.js
+++ b/src/containers/Settings/index.js
@@ -66,7 +66,7 @@ class Settings extends Component {
             <ListItem button>
                 <ListItemIcon><WalletIcon/></ListItemIcon>
                 <ListItemText
-                    primary='Bitcoin Wallet (testnet)'
+                    primary='Your Bitcoin Address (testnet)'
                     secondary={`${address} - Click to copy to clipboard`}
                 />
             </ListItem>

--- a/src/containers/Settings/index.js
+++ b/src/containers/Settings/index.js
@@ -4,18 +4,14 @@ import { get } from 'lodash'
 // components
 import { Button, Card, CardContent, CardActions, CardHeader } from '@material-ui/core'
 import { Avatar, withStyles, List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core'
-import ConfirmActionModal from 'components/Modals/ConfirmActionModal';
 import ReactCopyToClipBoard from 'react-copy-to-clipboard'
 // redux
 import { compose } from 'recompose';
 import { connect } from 'react-redux'
-import { deleteWallet, closeDeleteModal, openDeleteModal } from 'store/modules/data/wallet'
-import { push } from 'react-router-redux'
 // helpers
 import { downloadWallet, getAddress } from 'helpers/wallet';
 // icons
 import DownloadIcon from '@material-ui/icons/FileDownload'
-import DeleteIcon from '@material-ui/icons/Delete'
 import UserIcon from '@material-ui/icons/Person'
 import WalletIcon from '@material-ui/icons/AccountBalanceWallet'
 import ProfileIcon from '@material-ui/icons/AccountBalanceWallet'

--- a/src/containers/Transactions/index.js
+++ b/src/containers/Transactions/index.js
@@ -71,7 +71,7 @@ class Transactions extends Component {
         <Card className={classes.card}>
           <CardHeader
             avatar={<Avatar><WalletIcon/></Avatar>}
-            title='Bitcoin Wallet (Testnet)'
+            title='Your Bitcoin Address (Testnet)'
             subheader={address}
           />
         </Card>

--- a/src/helpers/wallet.js
+++ b/src/helpers/wallet.js
@@ -1,6 +1,7 @@
 import ImportPrivateKey from 'chlu-wallet-support-js/lib/import_private_key'
 import fileDownload from 'js-file-download'
 import ChluDID from 'chlu-did/src' // TODO: precompiled sources??
+import { pick } from 'lodash'
 
 export async function generateNewWallet() {
     const importer = new ImportPrivateKey()
@@ -20,7 +21,7 @@ export async function saveWalletDIDToIPFS(wallet) {
 }
 
 export function saveWalletToLocalStorage(wallet) {
-    localStorage.setItem('wallet', JSON.stringify(wallet))
+    localStorage.setIte('wallet', JSON.stringify(wallet))
 }
 
 export function getWalletFromLocalStorage() {
@@ -32,7 +33,12 @@ export function deleteWalletFromLocalStorage() {
 }
 
 export function downloadWallet(wallet) {
-    fileDownload(JSON.stringify(wallet, null, 2), 'chlu_wallet.json')
+    const obj = pick(wallet, [
+        'did',
+        'bitcoinMnemonic',
+        'testnet'
+    ])
+    fileDownload(JSON.stringify(obj, null, 2), 'chlu_wallet.json')
 }
 
 export function importWallet(str) {

--- a/src/helpers/wallet.js
+++ b/src/helpers/wallet.js
@@ -21,7 +21,7 @@ export async function saveWalletDIDToIPFS(wallet) {
 }
 
 export function saveWalletToLocalStorage(wallet) {
-    localStorage.setIte('wallet', JSON.stringify(wallet))
+    localStorage.setItem('wallet', JSON.stringify(wallet))
 }
 
 export function getWalletFromLocalStorage() {


### PR DESCRIPTION
made some improvements to the Settings page, so that it's easier to copy info for the login in flexhire

the logout button is gone (since it's in the layout) and the list items are clickable and they copy the info to the clipboard

- fixes #94 

![screenshot_20180615_161459](https://user-images.githubusercontent.com/2546805/41472732-9c9037d4-70b7-11e8-962f-0d024c5f0a8e.png)
