### PR TITLE
Pay custom PoPR by link with multihash

### DIFF
--- a/src/containers/Layout/MainLayout.js
+++ b/src/containers/Layout/MainLayout.js
@@ -58,7 +58,7 @@ class MainLayout extends Component {
             <Route path='/profile/:id' component={Profile} />
             {emptyWallet && <Redirect to='/'/>}
             <Route path='/search' component={Search} />
-            <Route path='/pay' component={Payment} />
+            <Route path='/pay/:multihash?' component={Payment} />
             <Route path='/reputation' component={Reputation} />
             <Route path='/wrote' component={ReviewsIWrote} />
             <Route path='/transactions' component={Transactions} />

--- a/src/containers/Payment/index.js
+++ b/src/containers/Payment/index.js
@@ -38,9 +38,9 @@ class Payment extends Component {
     this.props.getCheckout(this.props.match.params.multihash)
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.match.params.multihash !== this.props.match.params.multihash) {
-      this.props.getCheckout(nextProps.match.params.multihash)
+  componentDidUpdate(prevProps) {
+    if (this.props.match.params.multihash !== prevProps.match.params.multihash) {
+      this.props.getCheckout(this.props.match.params.multihash)
     }
   }
 

--- a/src/containers/Payment/index.js
+++ b/src/containers/Payment/index.js
@@ -35,7 +35,13 @@ const starCount = 5
 class Payment extends Component {
 
   componentDidMount() {
-    this.props.getCheckout()
+    this.props.getCheckout(this.props.match.params.multihash)
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.match.params.multihash !== this.props.match.params.multihash) {
+      this.props.getCheckout(nextProps.match.params.multihash)
+    }
   }
 
   handleSubmit(data) {
@@ -141,12 +147,19 @@ function mapStateToProps(state) {
   }
 }
 
+<<<<<<< HEAD
 function mapDispatchToProps(dispatch) {
   return {
     getCheckout: () => dispatch(getCheckout()),
     submitPayment: data => dispatch(submitPayment(data)),
     setRating: data => dispatch(setRatingForCustomerWallet(data))
   }
+=======
+const mapDispatchToProps = {
+    getCheckout,
+    submitPayment,
+    setRating: setRatingForCustomerWallet
+>>>>>>> can now pay custom PoPR by link with multihash
 }
 
 export default compose(

--- a/src/fixtures/checkout.js
+++ b/src/fixtures/checkout.js
@@ -1,9 +1,0 @@
-const checkoutData = {
-  avatar: 'https://www.apple-iphone.ru/wp-content/uploads/2014/01/iphone6-2.png',
-  product: 'Apple iPhone 6',
-  vendorAddress: 'ms4TpM57RWHnEq5PRFtfJ8bcdiXoUE3tfv',
-  rating: 4,
-  price: 25.00
-}
-
-export default checkoutData

--- a/src/helpers/marketplace.js
+++ b/src/helpers/marketplace.js
@@ -4,5 +4,7 @@ export async function requestPopr(url, vendorId, options = {}) {
   const response = await axios.post(url + '/vendors/' + vendorId + '/popr', {
     ...options
   })
+  console.log('PoPR From Marketplace:')
+  console.log(response.data)
   return response.data.popr
 }

--- a/src/store/modules/data/checkout.js
+++ b/src/store/modules/data/checkout.js
@@ -1,7 +1,6 @@
 import { createAction, handleActions } from 'redux-actions'
 import { requestPopr } from 'helpers/marketplace'
-// data
-import checkoutData from 'fixtures/checkout'
+import { getChluIPFS } from 'helpers/ipfs'
 
 // ------------------------------------
 // Constants
@@ -27,20 +26,39 @@ export const fetchCheckoutDataLoading = createAction(FETCH_CHECKOUT_DATA_LOADING
 // Thunks
 // ------------------------------------
 
-export function getCheckout () {
+export function getCheckout (poprMultihash) {
+  console.log(poprMultihash)
   return async dispatch => {
     dispatch(fetchCheckoutDataLoading(true))
+    let popr = null
     try {
-      // TODO: replace fixture data with stuff from PoPR
-      // TODO: handle error in UI
-      const vendorId = process.env.REACT_APP_VENDOR_ID || 'Qmtest'
-      const url = process.env.REACT_APP_MARKETPLACE_URL || 'http://localhost:4000'
-      const popr = await requestPopr(url, vendorId, {
-        // TODO: fix the placeholder price
-        amount: checkoutData.price * 10000,
-        currency_symbol: 'tBTC'
-      })
-      dispatch(fetchCheckoutDataSuccess(Object.assign({}, popr, checkoutData)))
+      if (poprMultihash) {
+        console.log('Reading PoPR at ' + poprMultihash)
+        const chluIpfs = await getChluIPFS()
+        // TODO: create API calls in Chlu to fetch PoPR instead of this manual thing
+        const buffer = await chluIpfs.instance.ipfsUtils.get(poprMultihash)
+        popr = await chluIpfs.instance.protobuf.PoPR.decode(buffer)
+        popr.multihash = poprMultihash
+        // TODO: validation
+        console.log('Read PoPR at ' + poprMultihash)
+      } else {
+        const vendorId = process.env.REACT_APP_VENDOR_ID || 'Qmtest'
+        const url = process.env.REACT_APP_MARKETPLACE_URL || 'http://localhost:4000'
+        console.log(`Requesting PoPR to ${url} for vendor ${vendorId}`)
+        popr = await requestPopr(url, vendorId, {
+          // TODO: fix the placeholder price
+          amount: 25 * 10000,
+          currency_symbol: 'tBTC'
+        })
+        popr.multihash = null
+        console.log(`Requested PoPR to ${url} for vendor ${vendorId}`)
+      }
+      // TODO: get vendor_address properly instead of using the hardcoded address
+      if (!popr.vendor_address) {
+        popr.vendor_address = process.env.REACT_APP_VENDOR_ADDRESS || 'ms4TpM57RWHnEq5PRFtfJ8bcdiXoUE3tfv'
+      }
+      console.log(popr)
+      dispatch(fetchCheckoutDataSuccess(Object.assign({}, popr)))
       return popr
     } catch (error) {
       dispatch(fetchCheckoutDataError(error.message || error))


### PR DESCRIPTION
The `/pay` URL works just as before

However a new `/pay/:multihash` URL is now available, the difference is that instead of calling the Marketplace to generate a PoPR, the wallet will load the PoPR from IPFS at the given multihash and use that for the payment and review.

This allows third party applications to link to the wallet and request a specific PoPR to be paid.

### How to test

- first open `/pay`. In the console or by inspecting the HTTP response you can get the multihash of the PoPR generated by the Marketplace. Or just use `QmfSsqHV3CwAkfj72uE5Rpw5ghA4M2NhZYeafEJnGRkJuK`
- open that PoPR with `/pay/multihash` and see that it does not make any HTTP requests.