### PR TITLE
allow custom payment amounts

### DIFF
--- a/src/containers/Payment/PaymentForm.js
+++ b/src/containers/Payment/PaymentForm.js
@@ -8,7 +8,7 @@ import StarRatingComponent from 'react-star-rating-component'
 // icons
 import ReviewIcon from '@material-ui/icons/Star'
 
-function PaymentForm({ handleSubmit, setRating, rating, starCount, disabled }) {
+function PaymentForm({ handleSubmit, onCancel, setRating, rating, starCount, disabled }) {
   return <form onSubmit={handleSubmit}>
         <CardHeader
             avatar={<Avatar><ReviewIcon/></Avatar>}
@@ -36,6 +36,7 @@ function PaymentForm({ handleSubmit, setRating, rating, starCount, disabled }) {
         </CardContent>
         <CardActions>
             <Button type='submit' disabled={disabled}>Pay</Button>
+            <Button onClick={onCancel}>Cancel</Button>
         </CardActions>
     </form>
 }

--- a/src/containers/Payment/index.js
+++ b/src/containers/Payment/index.js
@@ -159,7 +159,7 @@ class Payment extends Component {
                 primary={<TextField
                   type='number'
                   value={amount}
-                  onChange={this.changeAmoun}
+                  onChange={this.changeAmount}
                   error={!balanceSufficient}
                   helperText={balanceSufficient ? `You will pay ${amountMBtc} Testnet mBTC (${amountUSD} tUSD)` : `You do not have enough funds to cover this payment`}
                 />}

--- a/src/containers/Payment/index.js
+++ b/src/containers/Payment/index.js
@@ -57,23 +57,23 @@ class Payment extends Component {
     }
   }
 
-  getCheckout() {
+  getCheckout = () => {
     const amountMBtc = this.state.amount
     const amountSat = amountMBtc * 100000
     return this.props.getCheckout(this.props.didId, amountSat)
   }
 
-  cancel() {
+  cancel = () => {
     this.setState({ amount: 0 })
     this.props.cancelPayment()
   }
 
-  changeAmount(event) {
+  changeAmount = (event) => {
     const amountMBtc = event.target.value
     this.setState({ amount: amountMBtc })
   }
 
-  async handleSubmit(data) {
+  handleSubmit = async (data) => {
     const review = data.review || ''
     const rating = this.props.rating
     await this.props.submitPayment({ review, rating })
@@ -159,7 +159,7 @@ class Payment extends Component {
                 primary={<TextField
                   type='number'
                   value={amount}
-                  onChange={this.changeAmount.bind(this)}
+                  onChange={this.changeAmoun}
                   error={!balanceSufficient}
                   helperText={balanceSufficient ? `You will pay ${amountMBtc} Testnet mBTC (${amountUSD} tUSD)` : `You do not have enough funds to cover this payment`}
                 />}
@@ -187,7 +187,7 @@ class Payment extends Component {
           </List>
         </CardContent>
         <CardActions>
-          <Button disabled={!amount || !balanceSufficient} onClick={this.getCheckout.bind(this)}>Prepare Payment</Button>
+          <Button disabled={!amount || !balanceSufficient} onClick={this.getCheckout}>Prepare Payment</Button>
         </CardActions>
       </Card>
     } else {
@@ -230,8 +230,8 @@ class Payment extends Component {
           rating={rating}
           setRating={setRating}
           disabled={submitDisabled}
-          onSubmit={this.handleSubmit.bind(this)}
-          onCancel={this.cancel.bind(this)}
+          onSubmit={this.handleSubmit}
+          onCancel={this.cancel}
         />
       </Card>
     }

--- a/src/store/modules/data/checkout.js
+++ b/src/store/modules/data/checkout.js
@@ -39,7 +39,7 @@ export function getCheckout (vendorId, amount) {
       const url = process.env.REACT_APP_MARKETPLACE_URL || 'http://localhost:4000'
       console.log(`Requesting PoPR to ${url} for vendor ${vendorId} amount ${amount}`)
       popr = await requestPopr(url, vendorId, {
-        amount: String(amount),
+        amount: amount.toString(),
         currency_symbol: 'tBTC'
       })
       console.log(`Requesting Profile for vendor ${vendorId} to get vendorAddress`)

--- a/src/store/modules/data/checkout.js
+++ b/src/store/modules/data/checkout.js
@@ -9,39 +9,43 @@ import { get } from 'lodash'
 const FETCH_CHECKOUT_DATA_SUCCESS = 'checkout/FETCH_CHECKOUT_DATA_SUCCESS'
 const FETCH_CHECKOUT_DATA_ERROR = 'checkout/FETCH_CHECKOUT_DATA_ERROR'
 const FETCH_CHECKOUT_DATA_LOADING = 'checkout/FETCH_CHECKOUT_DATA_LOADING'
+const CANCEL_PAYMENT = 'checkout/CANCEL'
 
-const initialState = {
-  loading: false,
-  error: null,
-  data: {}
+function getInitialState () {
+  return {
+    loading: false,
+    error: null,
+    data: null
+  }
 }
 
 // ------------------------------------
 // Actions
 // ------------------------------------
-export const fetchCheckoutDataSuccess = createAction(FETCH_CHECKOUT_DATA_SUCCESS)
-export const fetchCheckoutDataError = createAction(FETCH_CHECKOUT_DATA_ERROR)
-export const fetchCheckoutDataLoading = createAction(FETCH_CHECKOUT_DATA_LOADING)
+const fetchCheckoutDataSuccess = createAction(FETCH_CHECKOUT_DATA_SUCCESS)
+const fetchCheckoutDataError = createAction(FETCH_CHECKOUT_DATA_ERROR)
+const fetchCheckoutDataLoading = createAction(FETCH_CHECKOUT_DATA_LOADING)
+export const cancelPayment = createAction(CANCEL_PAYMENT)
 
 // ------------------------------------
 // Thunks
 // ------------------------------------
 
-export function getCheckout ({ vendorId, amount }) {
+export function getCheckout (vendorId, amount) {
   return async dispatch => {
     dispatch(fetchCheckoutDataLoading(true))
-    let popr = null
     try {
+      let popr = null
       const url = process.env.REACT_APP_MARKETPLACE_URL || 'http://localhost:4000'
-      console.log(`Requesting PoPR to ${url} for vendor ${vendorId}`)
+      console.log(`Requesting PoPR to ${url} for vendor ${vendorId} amount ${amount}`)
       popr = await requestPopr(url, vendorId, {
-        amount,
+        amount: String(amount),
         currency_symbol: 'tBTC'
       })
       console.log(`Requesting Profile for vendor ${vendorId} to get vendorAddress`)
       const profile = await getProfile(vendorId)
       popr.vendor_address = get(profile, 'vendorAddress', null)
-      console.log(`Requested PoPR to ${url} for vendor ${vendorId}`)
+      console.log(`Requested PoPR to ${url} for vendor ${vendorId} amount ${amount}`)
       console.log(popr)
       dispatch(fetchCheckoutDataSuccess(popr))
       return popr
@@ -69,5 +73,6 @@ export default handleActions({
   [FETCH_CHECKOUT_DATA_LOADING]: (state, { payload: loading }) => ({
     ...state,
     loading
-  })
-}, initialState)
+  }),
+  [CANCEL_PAYMENT]: state => ({ ...state, data: null })
+}, getInitialState())


### PR DESCRIPTION
- user chooses the amount they want to pay in mBTC
- while the mBTC amount changes, the wallet displays how much that is in USD
- the balance is shown below the amount, and the user is prevented from paying and an error message shows up below the amount if it is greater than the wallet balance
- the user then clicks Prepare Payment and it brings them to a confirm screen where they see payment information and can enter a chlu review if they want
- also, the component always shows a loading message or indicator while it is doing operations, in detail:
  - while checking balance
  - while getting PoPR, after the user clicks Prepare Payment
  - while paying: there are 5 different loading steps each with its own message that tells the user which step the wallet is performing and how many there are in total

Questions

- should I make the user enter the review in the first screen and show a read only copy in the second screen instead?